### PR TITLE
Replace node-ipc with community maintained fork, update dependenies

### DIFF
--- a/find-open-socket.js
+++ b/find-open-socket.js
@@ -1,7 +1,7 @@
 const net = require('net');
 const os = require('os');
 const { join } = require('path');
-const ipc = require('node-ipc');
+const ipc = require("@node-ipc/node-ipc").default;
 
 ipc.config.silent = true;
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "electron": "^5.0.4",
-    "electron-is-dev": "^1.1.0",
-    "node-ipc": "^9.1.1",
-    "uuid": "^3.3.2"
+    "@node-ipc/node-ipc": "^11.0.3",
+    "electron": "^19.0.8",
+    "electron-is-dev": "^2.0.0",
+    "uuid": "^8.3.2"
   },
   "scripts": {
     "start": "electron ."


### PR DESCRIPTION
Remove [node-ipc](https://github.com/RIAEvangelist/node-ipc) and installed [@node-ipc/node-ipc](https://github.com/node-ipc/node-ipc), A community maintained fork of the original package.
Update dependency version for Electron, electron-is-dev and uuid.